### PR TITLE
Agentops pipeline and evaluation integration

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -17,6 +17,7 @@ book:
         - part1/reference-architecture.qmd
         - part1/deployment-pipeline.qmd
         - part1/1.3_deployment-pipeline.qmd
+        - part1/agentops-project-pipeline.qmd
     
     - part: "Part 2: Principles of Agent Ops"
       chapters:

--- a/part1/agentops-project-pipeline.qmd
+++ b/part1/agentops-project-pipeline.qmd
@@ -1,0 +1,144 @@
+# The Complete AgentOps Project Pipeline
+
+## Introduction
+
+Successfully deploying agent-based AI systems requires a systematic approach that spans from initial conception to continuous improvement. This chapter provides a concise roadmap for AgentOps projects, serving as your navigation guide through the entire development lifecycle.
+
+While achieving faster adoption rates than transformative technologies like the personal computer and internet [@bick2024rapid], a 2025 MIT study suggests that 95% of AI pilots fail [@estrada2025mit]. The key to bridging this gap lies in systematic evaluation—building the capability to measure AI quality at scale, which creates the reliability needed to earn trust from both end users and leadership stakeholders.
+
+This section walks through a typical agent development project flow and provides cross-references throughout the document to dive deep into each phase's detailed implementation guidance.
+
+## Phase 1: Project Conception and Team Formation
+
+### 1.1 Business Use Case Identification
+**Objective**: Define a focused, measurable business problem that agents can solve effectively.
+
+Avoid common anti-patterns like overly broad use cases or problems better solved with deterministic workflows. Focus on specific, well-scoped problems with clear success metrics.
+
+*→ Detailed coverage: [Part 1: Evolving Trends - Agent Ops Antipatterns](evolving-trends.qmd)*
+
+### 1.2 Cross-Functional Team Assembly
+**Objective**: Build a collaborative team with the right mix of technical and domain expertise.
+
+Assemble your core team including AI Engineers, Data Engineers, Software Engineers, Platform Engineers, Subject Matter Experts, Product Managers, and Executive Sponsors. Establish SME availability upfront—AI projects fail when developers must "beg for time" from domain experts.
+
+*→ Detailed coverage: [Part 3: Roles and Responsibilities](../part3/roles-responsibilities.qmd)*
+
+### 1.3 Stakeholder Alignment and Governance
+**Objective**: Create organizational alignment around evaluation importance and project governance.
+
+Establish governance frameworks, educate leadership on AI limitations, and plan communication strategies for regular stakeholder updates.
+
+*→ Detailed coverage: [Part 3: Stakeholder Management](../part3/stakeholder-management.qmd)*
+
+## Phase 2: Data Preprocessing and Indexing
+
+### 2.1 Data Architecture Planning
+**Objective**: Design data pipelines optimized for AI consumption rather than traditional analytics.
+
+Focus on unstructured data processing, semantic search capabilities, and multimodal content handling. Key differences from traditional ETL include vector storage, embedding generation, and LLM-based information extraction.
+
+*→ Detailed coverage: [Part 1: Reference Architecture](reference-architecture.qmd)*
+
+### 2.2 Production Data Infrastructure
+**Objective**: Implement robust, scalable data infrastructure with proper governance.
+
+Establish ACID transactions, quality monitoring, failure handling, and compliance frameworks for production-ready data pipelines.
+
+*→ Detailed coverage: [Part 1: Deployment Pipeline](deployment-pipeline.qmd)*
+
+## Phase 3: Agent Architecture Design
+
+### 3.1 Architecture Pattern Selection
+**Objective**: Choose the right level of complexity and framework for your use case.
+
+Evaluate DIY/Custom vs. Code-First Frameworks vs. Low-Code platforms based on your requirements. Avoid over-engineering with unnecessary supervisor-agent patterns when deterministic chains suffice.
+
+*→ Detailed coverage: [Part 1: Evolving Trends - Architecture Patterns](evolving-trends.qmd)*
+
+### 3.2 Cross-Functional Evaluation Planning
+**Objective**: Establish evaluation criteria through collaborative discovery between technical teams and domain experts.
+
+**The Cross-Functional Imperative**: Understanding what "good" looks like for complex, subjective AI outputs requires essential input from domain experts and end-users. This necessitates close collaboration to define evaluation guidelines aligned with specific business objectives.
+
+Implement Judge Calibration Workshops to convert human expertise into scalable automated evaluation. This hybrid approach between LLM judges and targeted human expertise is crucial for building trust, especially in regulated domains.
+
+*→ Detailed coverage: [Part 2: Feedback Principles](../part2/2.3_feedback-principles.qmd)*
+
+### 3.3 Guardrails and Safety Implementation
+**Objective**: Implement comprehensive safety measures and operational boundaries.
+
+Establish input validation, output monitoring, tool access controls, and operational limits to ensure safe and reliable agent behavior.
+
+*→ Detailed coverage: [Part 1: Reference Architecture - Guardrails](reference-architecture.qmd)*
+
+## Phase 4: Evaluation Framework Implementation
+
+### 4.1 The Testing Pyramid for AI Systems
+**Objective**: Build a comprehensive evaluation strategy from manual validation to automated monitoring.
+
+Start with manual SME review to understand quality patterns, then scale through automated LLM judges and programmatic checks. Implement both offline testing and online production monitoring.
+
+*→ Detailed coverage: [Part 2: Flow Principles - Test Suite Development](../part2/2.2_flow-principles.qmd)*
+
+### 4.2 Cost-Effective Evaluation Strategies
+**Objective**: Scale evaluation while managing token costs and computational overhead.
+
+Unlike traditional unit tests, LLM-based evaluations cost money. Implement token-efficient strategies, field-based vs. trace-based evaluation approaches, and smart sampling techniques.
+
+*→ Detailed coverage: [Part 2: Flow Principles - Evaluation Cost Management](../part2/2.2_flow-principles.qmd)*
+
+## Phase 5: Feedback Collection and Monitoring
+
+### 5.1 Multi-Source Feedback Integration
+**Objective**: Establish comprehensive feedback collection from all stakeholders.
+
+Integrate end-user feedback, SME validation, LLM judge assessment, and system metrics. Implement both pre-production structured reviews and production real-time collection mechanisms.
+
+*→ Detailed coverage: [Part 2: Feedback Principles](../part2/2.3_feedback-principles.qmd)*
+
+### 5.2 Production Telemetry and Observability
+**Objective**: Implement comprehensive monitoring for both system and AI-specific metrics.
+
+Monitor operational metrics (latency, cost), quality metrics (evaluation scores, user satisfaction), and business impact (ROI, efficiency gains). Ensure proper data protection and audit trails.
+
+*→ Detailed coverage: [Part 1: Deployment Pipeline - Monitoring](deployment-pipeline.qmd)*
+
+## Phase 6: Iterative Development and Optimization
+
+### 6.1 Continuous Learning Feedback Loop
+**Objective**: Establish systematic improvement cycles based on evaluation insights.
+
+Implement data collection, analysis, hypothesis formation, targeted improvements, validation, and deployment cycles. Focus on prompt engineering, tool selection, architecture tuning, and cost optimization.
+
+*→ Detailed coverage: [Part 2: Continuous Learning](../part2/2.4_continuous-learning.qmd)*
+
+### 6.2 Trust Building Through Transparency
+**Objective**: Build stakeholder confidence through demonstrable quality improvements.
+
+Use regular demonstrations, metric transparency, honest failure analysis, and user education to build trust. Transform evaluation data into reusable organizational assets.
+
+*→ Detailed coverage: [Part 2: Continuous Learning](../part2/2.4_continuous-learning.qmd)*
+
+## Phase 7: Scaling and Governance
+
+### 7.1 Enterprise Scaling and Risk Management
+**Objective**: Expand successful pilots to enterprise-wide deployment with proper governance.
+
+Address cost management, quality consistency, organizational change, and technical infrastructure scaling. Establish AI governance boards and compliance monitoring.
+
+*→ Detailed coverage: [Part 3: Hidden Technical Debt](../part3/hidden-technical-debt.qmd)*
+
+## Conclusion: Delivering Strategic Business Value
+
+Following this systematic pipeline transforms AI initiatives from experimental pilots into strategic business assets that drive measurable outcomes. Organizations that master this approach don't just deploy successful AI systems—they build the organizational capabilities, data assets, and operational excellence that create lasting competitive advantages.
+
+The systematic approach outlined in this pipeline enables organizations to:
+- **Accelerate time-to-value** through structured, repeatable processes
+- **Minimize project risk** by addressing common failure modes proactively  
+- **Scale AI capabilities** across the enterprise with consistent quality
+- **Generate measurable ROI** through improved efficiency and innovation
+- **Build organizational AI maturity** that compounds over future projects
+
+**Next Steps**: Use this pipeline as your project roadmap, diving into the detailed chapters referenced throughout for specific implementation guidance. Remember that successful AgentOps projects often iterate between phases as understanding deepens and requirements evolve.
+

--- a/part2/2.1_intro_devops-principles.qmd
+++ b/part2/2.1_intro_devops-principles.qmd
@@ -22,7 +22,15 @@ Generative AI applications present several fundamental differences from traditio
 
 **Expensive Evaluation**: Unlike traditional unit tests that run instantly and for free, LLM-based evaluations consume tokens and incur costs, requiring strategic approaches to test suite design.
 
-Because of these differences, evaluations can be challenging and cost to automate.
+Because of these differences, evaluations can be challenging and cost to automate. At the same time, evaluations are the bedrock of AI quality 
+
+### Evaluations are a Revenue Generator not a Cost Center
+
+AI system Evaluations are often viewed as a necessary evil, a compliance checkbox, or a drain on resources. Instead, evaluations should be viewed as a strategic investment that fundamentally de-risks AI initiatives, accelerates the deployment of reliable systems, and ultimately drives tangible business value and a durable competitive advantage.  The strategic importance of AI system evaluations can be viewed from two paradigms. 
+
+**Building more reliable AI systems right away**: Once in place, evaluations enable faster deployment to users, quantify performance changes, and inform deployment decisions by measuring against a company’s specific business problem. Robust, continuous evaluations provide the essential confidence needed to scale AI applications across the enterprise, ensuring they consistently meet performance, safety, and compliance standards. 
+
+**A forward looking strategic asset**: The data generated through evaluation—human feedback, LLM judge outputs, traces of agent behavior—is not just for a single model or agent. It is a highly valuable, reusable data asset that can be leveraged to train new models, validate evolving agentic workflows, and flexibly adapt to whatever comes next in the rapidly advancing AI landscape. Evaluations are the means to codify an organization’s proprietary expertise, creating a persistent competitive advantage in an increasingly AI-driven world.
 
 ### The Hybrid Nature of Generative AI Systems
 

--- a/part2/2.4_continuous-learning.qmd
+++ b/part2/2.4_continuous-learning.qmd
@@ -54,6 +54,28 @@ Provides 70-80% of the architectural decisions upfront, leaving teams to focus o
 
 ## Technical best practices
 
+## Collaborative Metric Development and LLM-as-a-Judge Calibration
+
+One of the most critical challenges in AgentOps is establishing effective evaluation criteria. Unlike traditional software and machine learning where success metrics are often clear-cut, evaluating agentic AI requires synthesizing knowledge scattered across different departments—from technical teams who understand system capabilities, to business leaders who own outcomes, to Subject Matter Experts (SMEs) who define quality in domain-specific contexts.
+
+Without this unified view, teams struggle with ambiguous success criteria and waste effort measuring against disparate, unwritten standards. It isn't possible to calibrate an automated judge if the success metric itself is not clear.
+
+### Building Shared Understanding Through Cross-Functional Collaboration
+
+When a technical lead, a domain expert, and a product manager review the same customer service response, they often disagree on what makes it "good" or "bad"—and that disagreement is exactly what you need to surface and resolve.
+
+Start by gathering concrete examples of your agent's outputs, ideally covering the range of scenarios you expect in production. Bring together representatives from each stakeholder group and work through these examples systematically. The technical team might focus on whether the agent used tools correctly, while the domain expert cares about accuracy and the product manager evaluates user experience.
+
+These sessions reveal the gaps between what different groups consider success. A response that's technically correct might still frustrate users if it's too verbose. An answer that delights users might concern compliance teams if it makes claims beyond the agent's knowledge base.
+
+The goal isn't to eliminate these different perspectives but to make them explicit and find ways to measure all the dimensions that matter. This usually means developing multiple evaluation criteria rather than trying to find a single "quality score."
+
+Once you've established shared criteria through human review, you can scale the evaluation using LLM judges trained on your team's collective understanding. These judges won't replace human oversight entirely, but they can handle the bulk of routine evaluation while flagging edge cases for human review.
+
+At Databricks, we've developed a research-backed workshop to help teams navigate this process more efficiently. Our GenAI specialists guide cross-functional teams through the discovery process using custom applications designed to streamline the collaborative review and automated judge calibration.
+
+This workshop is designed to solve that problem by bringing technical, business, and SME stakeholders together. By collectively reviewing concrete examples of agent responses—a process we call the Discovery Phase—your group will create a single, shared definition of what constitutes a "good" versus a "bad" response. This crucial collaboration allows us to define exactly WHAT we want to measure and translate your team's collective qualitative expertise into a quantitative framework for success. The ultimate outcome is not just an agreed-upon rubric, but a calibrated LLM-as-a-Judge that automatically scales this shared knowledge to reliably evaluate all future agent performance, saving countless hours and ensuring your AI is measured against metrics that truly matter to your business.
+
 ## Business stakeholder education
 
 Generative AI is not only a paradigm shift for how developers build applications, but how business users interact and use applications as well. 

--- a/part3/roles-responsibilities.qmd
+++ b/part3/roles-responsibilities.qmd
@@ -7,7 +7,7 @@ In this section, we will explore key roles and responsabilities within GenAI pro
 
 ## Key Roles
 
-Most organisations are consumers of AI models rather than builders. Their primary focus tends to be on integration and orchestration, agent systems, cost management, prompt engineering, and ensuring safety and governance.
+Most organisations are consumers of AI models rather than builders. These organizations are focused on building and deploying high quality agents that leverage existing models, while ensuring safety and controlling costs.
 
 The key roles listed below relate to how organisations implement GenAI. Because GenAI work requires significant collaboration, the exact division of responsibilities often depends on the organisation’s size. In some cases, one person may take on several roles, or hold a hybrid role that combines responsibilities from different areas.
 

--- a/part3/roles-responsibilities.qmd
+++ b/part3/roles-responsibilities.qmd
@@ -7,7 +7,7 @@ In this section, we will explore key roles and responsibilities within GenAI pro
 
 ## The Evolution of Roles in the GenAI Era
 
-Rather than training their own models, many organizations are focused on building and deploying high quality agents that leverage existing models, while ensuring safety and controlling costs. This shift has fundamentally changed the skills required and created new career paths.
+This shift has fundamentally changed the skills required from workers and created new career paths from them.
 
 In many cases, traditional data scientists who once focused on statistical modeling are transitioning to AI Engineers, applying their understanding of model behavior to prompt engineering and agent design. MLOps engineers are evolving into specialists who manage the unique challenges of LLM deployments. Data engineers are expanding their expertise to include vector databases and embedding pipelines.
 

--- a/part3/roles-responsibilities.qmd
+++ b/part3/roles-responsibilities.qmd
@@ -59,7 +59,7 @@ Primary Responsibilities:
 
 #### AI Platform Engineer {.unnumbered}
 
-A Platform Engineer in GenAI provides the scalable, cost-controlled infrastructure that enables AI applications to run reliably in production.
+A Gen  AI Platform Engineer provides scalable, cost-controlled infrastructure that enables AI applications to run reliably in production.
 
 Platform engineers have had to rapidly adapt to the unique challenges of AI infrastructure. Unlike traditional applications where resource usage is predictable, AI workloads can vary dramatically based on prompt length, model selection, and user behavior.
 

--- a/part3/roles-responsibilities.qmd
+++ b/part3/roles-responsibilities.qmd
@@ -145,7 +145,7 @@ Primary Responsibilities:
 
 An AI Safety Engineer acts as the security specialist for AI systems, implementing technical safeguards against adversarial attacks, harmful outputs, and system failures that traditional security approaches don't address. 
 
-In smaller organisations, these responsibilities are often distributed across AI engineers (who handle basic safety measures), security engineers (who manage traditional security concerns), or platform engineers (who oversee monitoring). However, the unique risks posed by AI—such as prompt injection, model manipulation, and hallucinations—are driving the need for specialised expertise. This trend is reinforced by the fact that leading AI labs like OpenAI, Anthropic, and DeepMind have dedicated AI safety teams, and both the UK and US governments established AI Safety Institutes in 2024 to tackle these emerging challenges.
+In smaller organisations, these responsibilities are often distributed across AI engineers (who handle basic safety measures), security engineers (who manage traditional security concerns), or platform engineers (who oversee monitoring). However, the unique risks posed by AI, such as prompt injection, model manipulation, and hallucinations, are driving the need for specialised expertise. This trend is reinforced by the fact that leading AI labs like OpenAI, Anthropic, and DeepMind have dedicated AI safety teams, and both the [UK](https://www.gov.uk/government/publications/ai-safety-institute-overview/introducing-the-ai-safety-institute) and [US](https://www.nist.gov/caisi) governments established AI Safety Institutes to tackle these emerging challenges.
 
 Primary Responsibilities:
 
@@ -195,7 +195,7 @@ Effective GenAI projects depend on strong cross-functional collaboration, with r
 
 | Role                | Interacts With            | Example Purpose of Interaction                              |
 |---------------------|---------------------------|-----------------------------------------------------|
-| **AI Engineer**     | Data Engineer             | Define vector DB & embedding requirements for RAG   |
+| **AI Engineer**     | Data Engineer             | Define vector DB and embedding requirements for RAG   |
 |                     | Software Engineer         | Integrate AI capabilities into applications         |
 |                     | Product Manager           | Translate business needs into feasible AI solutions |
 |                     | Platform Engineer         | Coordinate scaling, monitoring, cost optimization   |

--- a/part3/roles-responsibilities.qmd
+++ b/part3/roles-responsibilities.qmd
@@ -9,7 +9,7 @@ In this section, we will explore key roles and responsabilities within GenAI pro
 
 Most organisations are consumers of AI models rather than builders. These organizations are focused on building and deploying high quality agents that leverage existing models, while ensuring safety and controlling costs.
 
-The key roles listed below relate to how organisations implement GenAI. Because GenAI work requires significant collaboration, the exact division of responsibilities often depends on the organisation’s size. In some cases, one person may take on several roles, or hold a hybrid role that combines responsibilities from different areas.
+The key roles listed below relate to how organizations implement GenAI. Because GenAI work requires significant collaboration, the exact division of responsibilities often depends on the organization’s size. In some cases, one person may take on several roles, or hold a hybrid role that combines responsibilities from different areas.
 
 ### Technical Roles
 

--- a/part3/roles-responsibilities.qmd
+++ b/part3/roles-responsibilities.qmd
@@ -188,57 +188,34 @@ Primary Responsibilities:
 * Implement few-shot learning examples and chain-of-thought prompting
 * Optimize prompts for different models and use cases
 
-## Key Role Interactions {.unnumbered}
+## Key Role Interactions 
 
-Effective GenAI projects depend on strong cross-functional collaboration, with roles working together to align technical, operational, and business needs. The table below illustrates potential interactions between roles, along with examples of their purposes.
+Effective GenAI projects depend on strong cross-functional collaboration, with roles working together to align technical, operational, and business needs. Common collaboration patterns are:
 
+#### Agent Implementation Team {.unnumbered}
 
-| Role                | Interacts With            | Example Purpose of Interaction                              |
-|---------------------|---------------------------|-----------------------------------------------------|
-| **AI Engineer**     | Data Engineer             | Define vector DB and embedding requirements for RAG   |
-|                     | Software Engineer         | Integrate AI capabilities into applications         |
-|                     | Product Manager           | Translate business needs into feasible AI solutions |
-|                     | Platform Engineer         | Coordinate scaling, monitoring, cost optimization   |
-| **Data Engineer**   | AI Engineer               | Provide structured data & retrieval infrastructure  |
-|                     | Platform Engineer         | Scale data infra, manage storage                    |
-|                     | SME                       | Validate data relevance, preprocessing              |
-|                     | Software Engineer         | Support API/data access for features                |
-| **Software Engineer** | AI Engineer             | Consume AI services, implement UI/UX                |
-|                     | Product Manager           | Build user experiences to meet requirements         |
-|                     | Data Engineer             | Integrate APIs for data access                      |
-|                     | Platform Engineer         | Deploy apps, enable monitoring                      |
-| **Platform Engineer** | AI Engineer             | Model deployment, API management                    |
-|                     | Data Engineer             | Vector DB/data pipelines infra                      |
-|                     | Software Engineer         | CI/CD, deployment, monitoring                       |
-|                     | Cost Management           | Manage & optimize AI infra costs                    |
-| **SME**             | AI Engineer               | Provide domain knowledge for prompts, validation    |
-|                     | Product Manager           | Prioritize use cases based on business value        |
-|                     | Data Engineer             | Validate data quality                               |
-|                     | End Users                 | Gather feedback, validate AI solution               |
-| **Product Manager** | AI Engineer               | Assess feasibility, define success metrics          |
-|                     | Executive Sponsor         | Align with business goals, priorities               |
-|                     | SME                       | Validate use cases                                  |
-|                     | End Users                 | Collect feedback on usability                       |
-| **Executive Sponsor** | Product Manager         | Define strategic priorities                         |
-|                     | AI Ethics Officer         | Governance and risk frameworks                      |
-|                     | Cost Management           | AI investment, ROI tracking                         |
-|                     | Legal/Compliance          | Ensure regulatory compliance                        |
-| **AI Ethics Officer** | Executive Sponsor       | Advise on ethics, regulations                       |
-|                     | AI Safety Engineer        | Translate ethics into technical safeguards          |
-|                     | Legal/Compliance          | Ensure alignment with law                           |
-|                     | All Teams                 | Review implementations for compliance               |
-| **AI Safety Engineer** | AI Engineer            | Review implementations for vulnerabilities          |
-|                     | Platform Engineer         | Monitoring, alerting                                |
-|                     | AI Ethics Officer         | Align technical safety with ethical policies        |
-|                     | Security Teams            | Coordinate on AI-specific threats                   |
-| **LLMOps Engineer** | AI Engineer               | Support prompt optimization/testing                 |
-|                     | Platform Engineer         | Caching, routing infra                              |
-|                     | Data Engineer             | Context retrieval optimization                      |
-|                     | Cost Management           | Track & optimize model usage costs                  |
-| **Prompt Engineer** | AI Engineer               | Collaborate on production prompt implementation     |
-|                     | SME                       | Translate domain knowledge into prompts             |
-|                     | Product Manager           | Align prompts with user goals                       |
-|                     | End Users                 | Feedback on prompt effectiveness                    |
+**AI Engineer + Data Engineer + Platform Engineer**  
 
+- Co-develop agentic GenAI solutions, including retrieval-augmented generation (RAG) pipelines and tool integrations  
+- Joint responsibility for solution scalability, reliability, and performance  
 
+#### Product Development Chain  {.unnumbered}
 
+**Product Manager + AI Engineer + Software Engineer**  
+
+- Translate business requirements into GenAI features step by step  
+- Ensure clear handoffs with defined success criteria  
+
+#### AI Governance Board  {.unnumbered}
+
+**AI Ethics Officer + AI Safety Engineer + Legal/Compliance**  
+
+- Review GenAI implementations for ethical and legal compliance  
+- Conduct risk assessments and define mitigation strategies  
+
+#### Cost Management Team  {.unnumbered}
+
+**Finance + Platform Engineer + AI Engineer**  
+
+- Monitor and optimize GenAI usage and infrastructure costs  
+- Track ROI and align budget with business priorities  

--- a/part3/roles-responsibilities.qmd
+++ b/part3/roles-responsibilities.qmd
@@ -28,7 +28,8 @@ Primary Responsibilities:
 * Develop tools that give AI agents access to APIs and proprietary and external data sources
 * Design and implement the agent behavior
 * Build evaluation and testing suits to ensure quality
-* Optimize for cost and performance on the application logic level using prompt optimization, model selection, workflow design that minimizes API calls and response formatting that reduces token consumption.
+* Refine performance based on output of evaluation suits and SME feedback
+* Optimize agent design for cost and performance. Commonly used techniques include using prompt optimization, model selection, smart workflow designs that minimize API calls and response formatting that reduces token consumption
 * Deploy AI agents into production with proper versioning and monitoring
 
 #### Data Engineer {.unnumbered}

--- a/part3/roles-responsibilities.qmd
+++ b/part3/roles-responsibilities.qmd
@@ -39,7 +39,7 @@ Traditional data engineers are rapidly acquiring new skills in vector databases,
 
 Primary Responsibilities:
 
-* Design and maintain pipelines for structured data by delivering business data (e.g., customer records, product catalogs, transactions) into AI workflows by extracting from source systems, transforming into schemas, validating quality, and loading into feature stores or AI-ready tables
+* Design and maintain pipelines for structured data by delivering business data (e.g., customer records, product catalogs, transactions) into AI workflows by extracting from source systems, transforming into schemas, validating quality, and loading into feature stores or tables
 * Build pipelines for unstructured documents such as PDFs, emails, and reports, using OCR and text extraction, metadata tagging, text cleaning, chunking large documents and conversion into structured formats (e.g. JSON).
 * Develop preprocessing workflows for multimodal data (images, audio, video), including resizing images, extracting features, transcribing audio, segmenting videos, generating metadata and storing the outputs.
 * Support retrieval and embedding systems by building and maintaining vector databases for semantic search, implementing embedding pipelines, and running batch jobs to embed and update large document collections.
@@ -51,6 +51,8 @@ A software engineer integrates the agent into larger application, making AI capa
 
 Software engineers working with GenAI have had to adapt to non-deterministic systems. They've developed new patterns for handling variable response times, streaming outputs, and graceful degradation when AI services fail.
 
+Primary Responsibilities:
+
 * Design and building the user interface elements that make interactions with the GenAI solution smooth and intuitive, including real-time response streaming, typing indicators, and feedback tools, and conversation management
 * Develop backend services that integrate GenAI capabilities into existing core business applications
 * Implement application-level error handling and user-friendly fallback experiences, ensuring the application remains functional even when AI services are unavailable or produce unexpected results
@@ -61,6 +63,8 @@ Software engineers working with GenAI have had to adapt to non-deterministic sys
 A Platform Engineer in GenAI provides the scalable, cost-controlled infrastructure that enables AI applications to run reliably in production.
 
 Platform engineers have had to rapidly adapt to the unique challenges of AI infrastructure. Unlike traditional applications where resource usage is predictable, AI workloads can vary dramatically based on prompt length, model selection, and user behavior.
+
+Primary Responsibilities:
 
 * Provision and scale the infrastructure that supports GenAI services and applications
 * Build observability for GenAI systems (token usage monitoring, latency tracking, error rates)

--- a/part3/roles-responsibilities.qmd
+++ b/part3/roles-responsibilities.qmd
@@ -59,7 +59,7 @@ Primary Responsibilities:
 * Implement telemetry and logging for debugging interactions
 
 
-#### Platform Engineer {.unnumbered}
+#### AI Platform Engineer {.unnumbered}
 
 A Platform Engineer in GenAI provides the scalable, cost-controlled infrastructure that enables AI applications to run reliably in production, managing everything from API gateways to vector database operations.
 

--- a/part3/roles-responsibilities.qmd
+++ b/part3/roles-responsibilities.qmd
@@ -7,7 +7,7 @@ In this section, we will explore key roles and responsabilities within GenAI pro
 
 ## Key Roles
 
-Most organisations are consumers of AI models rather than builders. These organizations are focused on building and deploying high quality agents that leverage existing models, while ensuring safety and controlling costs.
+Rather than training their own models, most organizations are focused on building and deploying high quality agents that leverage existing models, while ensuring safety and controlling costs.
 
 The key roles listed below relate to how organizations implement GenAI. Because GenAI work requires significant collaboration, the exact division of responsibilities often depends on the organization’s size. In some cases, one person may take on several roles, or hold a hybrid role that combines responsibilities from different areas.
 
@@ -20,22 +20,22 @@ An AI Engineer integrates and optimizes pre-trained AI models into production ap
 
 Primary Responsibilities:
 
-* Integrate and fine-tune existing LLMs with most organizations using pre-trained models via APIs
-* Design and implement RAG (Retrieval Augmented Generation) architectures for domain specific applications
-* Develop prompt engineering strategies and optimize prompt templates for production use
-* Build evaluation and testing frameworks for non-deterministic AI systems, ensuring quality despite variable outputs
-* Optimize for cost and performance on the application logic level using prompt optimization, model selection, workflow design that minimizes API calls and output optimizaion.
-* Create AI agents workflows and orchestrate AI tool chains for complex tasks
-* Deploy AI models into production environments with proper versioning and monitoring
+* Integrate and fine-tune existing LLMs with business logic and data sources, typically using APIs to pre-trained models
+* Develop tools that give AI agents access to APIs and proprietary and external data sources
+* Design and implement the agent behavior
+* Build evaluation and testing to ensure quality
+* Refine performance based on evaluation output and feedback
+* Optimize for cost and performance on the application logic level using prompt optimization, model selection, workflow design that minimizes API calls and response formatting that reduces token consumption.
+* Deploy AI agents into production with proper versioning and monitoring
 
 #### Data Engineer {.unnumbered}
-GenAI Data Engineers support all data needs for AI applications. They're the bridge between raw data sources and AI systems, whether that's for RAG, AI agents, fine-tuning, analytics, or traditional business intelligence.
+GenAI Data Engineers support all data needs for AI applications. They're the bridge between raw data sources and AI systems, whether that's for RAG pipelines, AI agents, fine-tuning, analytics, or traditional business intelligence.
 
 Primary Responsibilities:
 
-* Create data pipelines that inject structured business data into AI prompts (customer records, product catalogs, transaction history)
-* Process unstructured documents for AI consumption
-* Handle multi-modal data preprocessing (images, audio, video) for specialized AI applications
+* Design and maintain data pipelines that deliver structured business data (e.g., customer records, product catalogs, transaction history) into AI workflows. This includes extracting the data from source systems, transforming it into defined schemas, validating data quality and loading the resulting data into a table or feature store.
+* Build pipelines to transform unstructured documents (e.g., PDFs, emails, reports) into machine readable formats. This includes OCR and text extraction, metadata tagging, text cleaning, chunking large documents, converting to structured formats (e.g. json).
+* Develop preprocessing workflows for multi-modal data (images, audio, video), including tasks such as resizing images, extracting features, transcribing audio, segmenting videos, generating metadata and storing the outputs.
 * Build and maintain vector databases for semantic search and document retrieval
 * Implement embedding pipelines using embedding models
 * Manage batch processing jobs for large-scale document embedding and updates
@@ -44,19 +44,11 @@ Primary Responsibilities:
 * Implement feedback loops to capture user interactions and AI system responses for analysis
 
 #### Software Engineer {.unnumbered}
-A Software Engineer in GenAI teams builds user-facing applications that seamlessly incorporate AI capabilities, handling the integration, interface, and reliability challenges of non-deterministic AI systems.
+A software engineer integrates the agent into larger application. This could involve: 
 
-Primary Responsibilities:
-
-* Build user interfaces for AI agents (e.g. chat interfaces, AI assistants)
-* Design and build the user interface elements that make interactions with the GenAI solution smooth and intuitive, such as real-time response streaming, typing indicators, and feedback tools
-* Develop backend services that integrate GenAI capabilities into core business processes and applications
-* Manage conversation state and session persistence in GenAI applications
+* Design and building the user interface elements that make interactions with the GenAI solution smooth and intuitive, such as real-time response streaming, typing indicators, and feedback tools
+* Develop backend services that integrate GenAI capabilities into existing core business applications
 * Implement application-level error handling and user-friendly fallback experiences
-* Create end-to-end testing strategies for features with non-deterministic GenAI components
-* Optimize application performance
-* Ensure GenAI solutions are reliably released and continuously monitored through CI/CD pipelines
-* Implement telemetry and logging for debugging interactions
 
 
 #### AI Platform Engineer {.unnumbered}

--- a/part3/roles-responsibilities.qmd
+++ b/part3/roles-responsibilities.qmd
@@ -2,7 +2,7 @@
 
 ## Introduction
 
-The emergence of AgentOps represents a fundamental shift in how organizations structure and manage AI-powered systems. It introduces the need for new role definitions, collaborative patterns, and operational frameworks to handle AI agents, non-deterministic behaviors, and multi-agent interactions. This evolution requires both role specialization and cross-functional integration.
+The emergence of AgentOps represents a fundamental shift in how organizations structure and manage AI-powered systems. It introduces the need for new roles, collaborative patterns, and operational frameworks to handle the non-deterministic behaviors of AI agents and multi-agent interactions. This evolution requires both role specialization and cross-functional collaboration.
 In this section, we will explore key roles and responsabilities within GenAI projects.
 
 ## Key Roles

--- a/part3/roles-responsibilities.qmd
+++ b/part3/roles-responsibilities.qmd
@@ -82,7 +82,7 @@ Primary Responsibilities:
 
 * Validate GenAI solution outputs for domain accuracy and relevance  
 * Identify high value use cases specific to the business domain  
-* Provide training data examples and feedback for prompt optimization  
+* Provide training data examples and feedback that is used to improve agent quality
 * Define domain specific quality criteria and acceptance thresholds  
 * Bridge communication between technical teams and business stakeholders  
 * Ensure GenAI solutions comply with industry regulations and standards  

--- a/part3/roles-responsibilities.qmd
+++ b/part3/roles-responsibilities.qmd
@@ -46,7 +46,7 @@ Primary Responsibilities:
 
 
 #### Software Engineer {.unnumbered}
-A software engineer integrates the agent into larger application, making AI capabilities accessible and reliable for end users.
+A software engineer integrates the agent system into a larger application, making AI capabilities accessible for end users. Common end-user interfaces include bot integrations with Slack and Microsoft Teams, summary analysis reports delivered to an inbox daily, or standalone chat interfaces. 
 
 Software engineers working with GenAI have had to adapt to non-deterministic systems. They've developed new patterns for handling variable response times, streaming outputs, and graceful degradation when AI services fail.
 

--- a/part3/roles-responsibilities.qmd
+++ b/part3/roles-responsibilities.qmd
@@ -2,13 +2,243 @@
 
 ## Introduction
 
-Defining team structures and responsibilities for agent operations.
+The emergence of AgentOps represents a fundamental shift in how organizations structure and manage AI-powered systems. It introduces the need for new role definitions, collaborative patterns, and operational frameworks to handle AI agents, non-deterministic behaviors, and multi-agent interactions. This evolution requires both role specialization and cross-functional integration.
+In this section, we will explore key roles and responsabilities within GenAI projects.
 
 ## Key Roles
 
-- Agent Engineers
-- MLOps Engineers
-- Data Scientists
-- Platform Engineers
+Most organisations are consumers of AI models rather than builders. Their primary focus tends to be on integration and orchestration, agent systems, cost management, prompt engineering, and ensuring safety and governance.
 
-*Content to be developed*
+The key roles listed below relate to how organisations implement GenAI. Because GenAI work requires significant collaboration, the exact division of responsibilities often depends on the organisation’s size. In some cases, one person may take on several roles, or hold a hybrid role that combines responsibilities from different areas.
+
+### Technical Roles
+
+These roles directly build, implement, and maintain AI systems, handling the hands-on technical work and domain expertise required to deliver AI solutions.
+
+#### AI Engineer {.unnumbered}
+An AI Engineer integrates and optimizes pre-trained AI models into production applications, focusing on making AI capabilities work reliably and cost-effectively within business systems rather than building models from scratch.
+
+Primary Responsibilities:
+
+* Integrate and fine-tune existing LLMs with most organizations using pre-trained models via APIs
+* Design and implement RAG (Retrieval Augmented Generation) architectures for domain specific applications
+* Develop prompt engineering strategies and optimize prompt templates for production use
+* Build evaluation and testing frameworks for non-deterministic AI systems, ensuring quality despite variable outputs
+* Optimize for cost and performance on the application logic level using prompt optimization, model selection, workflow design that minimizes API calls and output optimizaion.
+* Create AI agents workflows and orchestrate AI tool chains for complex tasks
+* Deploy AI models into production environments with proper versioning and monitoring
+
+#### Data Engineer {.unnumbered}
+GenAI Data Engineers support all data needs for AI applications. They're the bridge between raw data sources and AI systems, whether that's for RAG, AI agents, fine-tuning, analytics, or traditional business intelligence.
+
+Primary Responsibilities:
+
+* Create data pipelines that inject structured business data into AI prompts (customer records, product catalogs, transaction history)
+* Process unstructured documents for AI consumption
+* Handle multi-modal data preprocessing (images, audio, video) for specialized AI applications
+* Build and maintain vector databases for semantic search and RAG applications
+* Implement embedding pipelines using embedding models
+* Manage batch processing jobs for large-scale document embedding and updates
+* Prepare and version datasets for model fine-tuning when required
+* Ensure data quality, governance, and compliance for all AI projects related data
+* Implement feedback loops to capture user interactions and AI system responses for analysis
+
+#### Software Engineer {.unnumbered}
+A Software Engineer in GenAI teams builds user-facing applications that seamlessly incorporate AI capabilities, handling the integration, interface, and reliability challenges of non-deterministic AI systems.
+
+Primary Responsibilities:
+
+* Build user interfaces for AI agents (e.g. chat interfaces, AI assistants)
+* Design and build the user interface elements that make interactions with the GenAI solution smooth and intuitive, such as real-time response streaming, typing indicators, and feedback tools
+* Develop backend services that integrate GenAI capabilities into core business processes and applications
+* Manage conversation state and session persistence in GenAI applications
+* Implement application-level error handling and user-friendly fallback experiences
+* Create end-to-end testing strategies for features with non-deterministic GenAI components
+* Optimize application performance
+* Ensure GenAI solutions are reliably released and continuously monitored through CI/CD pipelines
+* Implement telemetry and logging for debugging interactions
+
+
+#### Platform Engineer {.unnumbered}
+
+A Platform Engineer in GenAI provides the scalable, cost-controlled infrastructure that enables AI applications to run reliably in production, managing everything from API gateways to vector database operations.
+
+* Provision and scale the infrastructure that supports GenAI services and applications
+* Implement cost optimization strategies (caching layers, rate limiting, usage caps)
+* Build observability for GenAI systems (token usage monitoring, latency tracking, error rates)
+* Manage API gateway configurations and load balancing across providers
+* Handle multi-cloud orchestration and resource allocation
+* Create CI/CD pipelines for GenAI application deployments
+* Monitor and optimize infrastructure costs and performance
+* Set up alerting for cost overruns and system failures
+* Manage API keys, quotas, and provider relationships
+
+
+#### Subject Matter Expert (SME) {.unnumbered}
+
+A Subject Matter Expert brings deep domain knowledge to ensure AI solutions accurately address real business problems and comply with industry specific requirements.
+
+Primary Responsibilities:
+
+* Validate GenAI solution outputs for domain accuracy and relevance  
+* Identify high value use cases specific to the business domain  
+* Provide training data examples and feedback for prompt optimization  
+* Define domain specific quality criteria and acceptance thresholds  
+* Bridge communication between technical teams and business stakeholders  
+* Ensure GenAI solutions comply with industry regulations and standards  
+* Create domain specific evaluation criteria for GenAI solution performance 
+
+### Leadership and Strategy Roles
+
+These roles provide strategic direction, governance, and organizational alignment, ensuring AI initiatives deliver business value while maintaining ethical standards.
+
+#### Product Manager {.unnumbered}
+
+A GenAI Product Manager bridges business needs and technical capabilities, defining the strategy and roadmap for AI-powered products while ensuring they deliver measurable value to users and the organization.
+
+Primary Responsibilities:
+
+* Identify and prioritize AI use cases based on business value and technical feasibility
+* Define success metrics for AI features (user engagement, cost per interaction, value delivered)
+* Balance AI capabilities with user experience and ethical considerations
+* Manage stakeholder expectations about AI limitations and non-deterministic behavior
+* Create product roadmaps that leverage emerging AI capabilities
+* Conduct competitive analysis of AI features in the market
+* Define acceptable accuracy thresholds and quality standards for AI outputs
+
+#### Executive Sponsor {.unnumbered}
+
+An Executive Sponsor champions AI transformation at the organizational level, securing resources, removing barriers, and ensuring AI initiatives align with strategic business objectives.
+
+Primary Responsibilities:
+
+* Champion AI adoption and cultural transformation across the organization
+* Allocate budget for AI infrastructure, tools, and talent
+* Establish AI governance frameworks and ethical guidelines
+* Manage board and stakeholder communications about AI initiatives
+* Drive organizational change management for AI adoption
+* Set strategic direction for AI investment and risk tolerance
+* Ensure AI initiatives align with business strategy and compliance requirements 
+
+### Emerging Specialized Roles
+
+While many organizations currently distribute these responsibilities among existing technical roles, leading companies are creating dedicated positions as AI systems become more complex and mission-critical.
+
+#### AI Ethics Officer {.unnumbered}
+
+An AI Ethics Officer is responsible for establishing and enforcing governance frameworks that ensure AI systems are developed and deployed responsibly, balancing innovation with ethical principles and regulatory compliance. This includes addressing issues such as fairness, transparency, accountability, and the broader social impacts of AI adoption.
+
+At present, these responsibilities are most often distributed across compliance officers (regulatory alignment), data governance teams (fairness and bias mitigation), and product or research leaders (responsible design and deployment). However, with the growing complexity of AI systems and the rise of formal regulations like the [EU AI Act](https://artificialintelligenceact.eu/the-act/), the need for a dedicated role is becoming increasingly clear. As a result, the AI Ethics Officer is emerging as a specialised function in larger organisations and regulated industries.
+
+Primary Responsibilities:
+
+* Develop and enforce responsible AI policies and frameworks
+* Conduct bias audits and fairness assessments of AI systems
+* Ensure compliance with AI regulations (EU AI Act, industry standards)
+* Lead AI governance committees and review boards
+* Manage stakeholder communications about AI ethics
+* Oversee data privacy and consent for AI systems
+* Document AI decision-making processes for accountability
+
+
+#### AI Safety Engineer {.unnumbered}
+
+An AI Safety Engineer acts as the security specialist for AI systems, implementing technical safeguards against adversarial attacks, harmful outputs, and system failures that traditional security approaches don't address. 
+
+In smaller organisations, these responsibilities are often distributed across AI engineers (who handle basic safety measures), security engineers (who manage traditional security concerns), or platform engineers (who oversee monitoring). However, the unique risks posed by AI—such as prompt injection, model manipulation, and hallucinations—are driving the need for specialised expertise. This trend is reinforced by the fact that leading AI labs like OpenAI, Anthropic, and DeepMind have dedicated AI safety teams, and both the UK and US governments established AI Safety Institutes in 2024 to tackle these emerging challenges.
+
+Primary Responsibilities:
+
+* Implement guardrails against prompt injection and jailbreaking attempts
+* Build content filtering and moderation systems for AI outputs
+* Monitor for agent behavior drift and degradation in production
+* Develop testing frameworks for edge cases and failure modes
+* Create incident response procedures for AI failures
+* Implement audit trails for AI decision-making
+* Design fallback mechanisms and human-in-the-loop systems
+
+
+#### LLMOps Engineer {.unnumbered}
+
+An LLMOps Engineer specializes in the operational complexities unique to large language models, including managing prompt versioning, token optimization, model routing and managing inference costs at scale. 
+
+While AI Engineers and Platform Engineers currently share these duties in most organizations, the complexity of managing multiple models, providers, and deployment patterns is driving specialization.
+
+Primary Responsibilities:
+
+* Manage prompt versioning and A/B testing systems
+* Optimize context windows and token usage across applications
+* Implement prompt caching and response caching strategies
+* Build routing systems for multi-model deployments
+* Monitor and optimize inference costs across different models
+* Create automated testing for prompt effectiveness
+* Manage model migrations and deprecations
+
+#### Prompt Engineer {.unnumbered}
+
+A Prompt Engineer translates business requirements into optimized instructions for AI models, systematically testing and refining prompts to improve accuracy while reducing costs. Today, these responsibilities are typically distributed among AI engineers (technical implementation), subject matter experts (domain knowledge), and product managers (use case definition). However, as organisations expand their use of generative AI, the complexity and scale of prompt design are driving the need for dedicated expertise. With prompt optimisation capable of delivering significant cost savings and the growing need for model-specific prompting techniques, specialised roles are becoming increasingly valuable.
+
+Primary Responsibilities:
+
+* Design and optimize prompt templates for specific business use cases
+* Create prompt libraries and maintain documentation
+* Conduct systematic testing of prompt variations
+* Train non-technical teams on effective AI tool usage
+* Develop prompt engineering guidelines and best practices
+* Implement few-shot learning examples and chain-of-thought prompting
+* Optimize prompts for different models and use cases
+
+## Key Role Interactions {.unnumbered}
+
+Effective GenAI projects depend on strong cross-functional collaboration, with roles working together to align technical, operational, and business needs. The table below illustrates potential interactions between roles, along with examples of their purposes.
+
+
+| Role                | Interacts With            | Example Purpose of Interaction                              |
+|---------------------|---------------------------|-----------------------------------------------------|
+| **AI Engineer**     | Data Engineer             | Define vector DB & embedding requirements for RAG   |
+|                     | Software Engineer         | Integrate AI capabilities into applications         |
+|                     | Product Manager           | Translate business needs into feasible AI solutions |
+|                     | Platform Engineer         | Coordinate scaling, monitoring, cost optimization   |
+| **Data Engineer**   | AI Engineer               | Provide structured data & retrieval infrastructure  |
+|                     | Platform Engineer         | Scale data infra, manage storage                    |
+|                     | SME                       | Validate data relevance, preprocessing              |
+|                     | Software Engineer         | Support API/data access for features                |
+| **Software Engineer** | AI Engineer             | Consume AI services, implement UI/UX                |
+|                     | Product Manager           | Build user experiences to meet requirements         |
+|                     | Data Engineer             | Integrate APIs for data access                      |
+|                     | Platform Engineer         | Deploy apps, enable monitoring                      |
+| **Platform Engineer** | AI Engineer             | Model deployment, API management                    |
+|                     | Data Engineer             | Vector DB/data pipelines infra                      |
+|                     | Software Engineer         | CI/CD, deployment, monitoring                       |
+|                     | Cost Management           | Manage & optimize AI infra costs                    |
+| **SME**             | AI Engineer               | Provide domain knowledge for prompts, validation    |
+|                     | Product Manager           | Prioritize use cases based on business value        |
+|                     | Data Engineer             | Validate data quality                               |
+|                     | End Users                 | Gather feedback, validate AI solution               |
+| **Product Manager** | AI Engineer               | Assess feasibility, define success metrics          |
+|                     | Executive Sponsor         | Align with business goals, priorities               |
+|                     | SME                       | Validate use cases                                  |
+|                     | End Users                 | Collect feedback on usability                       |
+| **Executive Sponsor** | Product Manager         | Define strategic priorities                         |
+|                     | AI Ethics Officer         | Governance and risk frameworks                      |
+|                     | Cost Management           | AI investment, ROI tracking                         |
+|                     | Legal/Compliance          | Ensure regulatory compliance                        |
+| **AI Ethics Officer** | Executive Sponsor       | Advise on ethics, regulations                       |
+|                     | AI Safety Engineer        | Translate ethics into technical safeguards          |
+|                     | Legal/Compliance          | Ensure alignment with law                           |
+|                     | All Teams                 | Review implementations for compliance               |
+| **AI Safety Engineer** | AI Engineer            | Review implementations for vulnerabilities          |
+|                     | Platform Engineer         | Monitoring, alerting                                |
+|                     | AI Ethics Officer         | Align technical safety with ethical policies        |
+|                     | Security Teams            | Coordinate on AI-specific threats                   |
+| **LLMOps Engineer** | AI Engineer               | Support prompt optimization/testing                 |
+|                     | Platform Engineer         | Caching, routing infra                              |
+|                     | Data Engineer             | Context retrieval optimization                      |
+|                     | Cost Management           | Track & optimize model usage costs                  |
+| **Prompt Engineer** | AI Engineer               | Collaborate on production prompt implementation     |
+|                     | SME                       | Translate domain knowledge into prompts             |
+|                     | Product Manager           | Align prompts with user goals                       |
+|                     | End Users                 | Feedback on prompt effectiveness                    |
+
+
+

--- a/part3/roles-responsibilities.qmd
+++ b/part3/roles-responsibilities.qmd
@@ -3,20 +3,24 @@
 ## Introduction
 
 The emergence of AgentOps represents a fundamental shift in how organizations structure and manage AI-powered systems. It introduces the need for new roles, collaborative patterns, and operational frameworks to handle the non-deterministic behaviors of AI agents and multi-agent interactions. This evolution requires both role specialization and cross-functional collaboration.
-In this section, we will explore key roles and responsabilities within GenAI projects.
+In this section, we will explore key roles and responsibilities within GenAI projects, examining how traditional positions are evolving and what new patterns of collaboration are emerging.
 
-## Key Roles
+## The Evolution of Roles in the GenAI Era
 
-Rather than training their own models, most organizations are focused on building and deploying high quality agents that leverage existing models, while ensuring safety and controlling costs.
+Rather than training their own models, many organizations are focused on building and deploying high quality agents that leverage existing models, while ensuring safety and controlling costs. This shift has fundamentally changed the skills required and created new career paths.
 
-The key roles listed below relate to how organizations implement GenAI. Because GenAI work requires significant collaboration, the exact division of responsibilities often depends on the organization’s size. In some cases, one person may take on several roles, or hold a hybrid role that combines responsibilities from different areas.
+In many cases, traditional data scientists who once focused on statistical modeling are transitioning to AI Engineers, applying their understanding of model behavior to prompt engineering and agent design. MLOps engineers are evolving into specialists who manage the unique challenges of LLM deployments. Data engineers are expanding their expertise to include vector databases and embedding pipelines.
+
+The key roles listed below reflect this evolution, showing how organizations are adapting their talent strategies for GenAI implementation. Because GenAI work requires significant collaboration, the exact division of responsibilities often depends on the organization's size. In some cases, one person may take on several roles, or hold a hybrid position that combines responsibilities from different areas.
 
 ### Technical Roles
 
-These roles directly build, implement, and maintain AI systems, handling the hands-on technical work and domain expertise required to deliver AI solutions.
+These roles directly build, implement, and maintain AI systems, handling the hands on technical work and domain expertise required to deliver AI solutions. The technical landscape has shifted dramatically, with teams moving from months of model training to a focus on integration, optimization, and ensuring reliable agent behavior.
 
 #### AI Engineer {.unnumbered}
 An AI Engineer integrates and optimizes pre-trained AI models into production applications, focusing on making AI capabilities work reliably and cost-effectively within business systems rather than building models from scratch.
+
+Many of today's AI Engineers come from diverse backgrounds: software engineers bring system design and production expertise, data scientists contribute their understanding of model behavior and evaluation, while ML engineers naturally transition their model deployment skills to the LLM era. This diversity is essential because AI Engineers must understand both the probabilistic nature of AI models and the deterministic requirements of production systems.
 
 Primary Responsibilities:
 
@@ -31,36 +35,39 @@ Primary Responsibilities:
 #### Data Engineer {.unnumbered}
 GenAI Data Engineers support all data needs for AI applications. They're the bridge between raw data sources and AI systems, whether that's for RAG pipelines, AI agents, fine-tuning, analytics, or traditional business intelligence.
 
+Traditional data engineers are rapidly acquiring new skills in vector databases, embedding models, and unstructured data processing. The shift from structured SQL databases to semantic search has required a fundamental rethinking of data architecture. 
+
 Primary Responsibilities:
 
-* Design and maintain data pipelines that deliver structured business data (e.g., customer records, product catalogs, transaction history) into AI workflows. This includes extracting the data from source systems, transforming it into defined schemas, validating data quality and loading the resulting data into a table or feature store.
-* Build pipelines to transform unstructured documents (e.g., PDFs, emails, reports) into machine readable formats. This includes OCR and text extraction, metadata tagging, text cleaning, chunking large documents, converting to structured formats (e.g. json).
-* Develop preprocessing workflows for multi-modal data (images, audio, video), including tasks such as resizing images, extracting features, transcribing audio, segmenting videos, generating metadata and storing the outputs.
-* Build and maintain vector databases for semantic search and document retrieval
-* Implement embedding pipelines using embedding models
-* Manage batch processing jobs for large-scale document embedding and updates
-* Prepare and version datasets for model fine-tuning when required
-* Ensure data quality, governance, and compliance for all AI projects related data
-* Implement feedback loops to capture user interactions and AI system responses for analysis
+* Design and maintain pipelines for structured data by delivering business data (e.g., customer records, product catalogs, transactions) into AI workflows by extracting from source systems, transforming into schemas, validating quality, and loading into feature stores or AI-ready tables
+* Build pipelines for unstructured documents such as PDFs, emails, and reports, using OCR and text extraction, metadata tagging, text cleaning, chunking large documents and conversion into structured formats (e.g. JSON).
+* Develop preprocessing workflows for multimodal data (images, audio, video), including resizing images, extracting features, transcribing audio, segmenting videos, generating metadata and storing the outputs.
+* Support retrieval and embedding systems by building and maintaining vector databases for semantic search, implementing embedding pipelines, and running batch jobs to embed and update large document collections.
+* Manage data lifecycle and quality by versioning datasets for fine-tuning, enforcing data quality and governance, and implementing feedback loops that capture user interactions for continuous improvement.
+
 
 #### Software Engineer {.unnumbered}
-A software engineer integrates the agent into larger application. This could involve: 
+A software engineer integrates the agent into larger application, making AI capabilities accessible and reliable for end users.
 
-* Design and building the user interface elements that make interactions with the GenAI solution smooth and intuitive, such as real-time response streaming, typing indicators, and feedback tools
+Software engineers working with GenAI have had to adapt to non-deterministic systems. They've developed new patterns for handling variable response times, streaming outputs, and graceful degradation when AI services fail.
+
+* Design and building the user interface elements that make interactions with the GenAI solution smooth and intuitive, including real-time response streaming, typing indicators, and feedback tools, and conversation management
 * Develop backend services that integrate GenAI capabilities into existing core business applications
-* Implement application-level error handling and user-friendly fallback experiences
+* Implement application-level error handling and user-friendly fallback experiences, ensuring the application remains functional even when AI services are unavailable or produce unexpected results
 
 
 #### AI Platform Engineer {.unnumbered}
 
-A Platform Engineer in GenAI provides the scalable, cost-controlled infrastructure that enables AI applications to run reliably in production, managing everything from API gateways to vector database operations.
+A Platform Engineer in GenAI provides the scalable, cost-controlled infrastructure that enables AI applications to run reliably in production.
+
+Platform engineers have had to rapidly adapt to the unique challenges of AI infrastructure. Unlike traditional applications where resource usage is predictable, AI workloads can vary dramatically based on prompt length, model selection, and user behavior.
 
 * Provision and scale the infrastructure that supports GenAI services and applications
-* Implement cost optimization strategies (caching layers, rate limiting, usage caps)
 * Build observability for GenAI systems (token usage monitoring, latency tracking, error rates)
 * Manage API gateway configurations and load balancing across providers
 * Handle multi-cloud orchestration and resource allocation
 * Create CI/CD pipelines for GenAI application deployments
+* Implement cost optimization strategies (caching layers, rate limiting, usage caps)
 * Monitor and optimize infrastructure costs and performance
 * Set up alerting for cost overruns and system failures
 * Manage API keys, quotas, and provider relationships
@@ -70,50 +77,56 @@ A Platform Engineer in GenAI provides the scalable, cost-controlled infrastructu
 
 A Subject Matter Expert brings deep domain knowledge to ensure AI solutions accurately address real business problems and comply with industry specific requirements.
 
+SMEs have become increasingly critical as organizations realize that genAI solutions need substantial domain expertise to be useful. Unlike the ML era where SMEs primarily provided training data, they now actively participate in output validation and continuous improvement cycles.
+
 Primary Responsibilities:
 
-* Validate GenAI solution outputs for domain accuracy and relevance  
-* Identify high value use cases specific to the business domain  
+* Validate GenAI solution outputs for domain accuracy and relevance, catching subtle errors that automated testing might miss  
+* Identify high value use cases specific to the business domain, prioritizing AI applications that deliver real business value  
 * Provide training data examples and feedback that is used to improve agent quality
 * Define domain specific quality criteria and acceptance thresholds  
-* Bridge communication between technical teams and business stakeholders  
-* Ensure GenAI solutions comply with industry regulations and standards  
+* Bridge communication between technical teams and business stakeholders, translating complex requirements into actionable specifications  
+* Ensure GenAI solutions comply with industry regulations and standards, a critical responsibility in regulated industries like healthcare and finance  
 
 ### Leadership and Strategy Roles
 
-These roles provide strategic direction, governance, and organizational alignment, ensuring AI initiatives deliver business value while maintaining ethical standards.
+The strategic importance of GenAI has elevated these roles to new prominence. Unlike traditional IT projects that might report through middle management, GenAI initiatives often have direct C-suite visibility due to the high risks involved from significant financial investments and potential regulatory violations to reputational damage from AI failures. This combination of high stakes and executive scrutiny fundamentally changes how these roles operate, requiring leaders who can navigate both technical complexity and boardroom politics.
 
 #### Product Manager {.unnumbered}
 
 A GenAI Product Manager bridges business needs and technical capabilities, defining the strategy and roadmap for AI-powered products while ensuring they deliver measurable value to users and the organization.
 
+Product managers in the GenAI era face the challenges of managing stakeholder expectations about non-deterministic systems, balancing innovation with risk, and navigating rapidly evolving capabilities. This role has become more technical, requiring deeper understanding of model capabilities and limitations. The pace of change means roadmaps are revised monthly rather than quarterly, and competitive analysis has become a daily activity as new AI features appear constantly.
+
 Primary Responsibilities:
 
 * Identify and prioritize AI use cases based on business value and technical feasibility
 * Define success metrics for AI features (user engagement, cost per interaction, value delivered)
-* Balance AI capabilities with user experience and ethical considerations
-* Manage stakeholder expectations about AI limitations and non-deterministic behavior
-* Create product roadmaps that leverage emerging AI capabilities
+* Balance AI capabilities with user experience and ethical considerations, ensuring that AI enhances rather than complicates user journeys
+* Manage stakeholder expectations about AI limitations and non-deterministic behavior, educating leadership about what AI can and cannot do
+* Create product roadmaps that leverage emerging AI capabilities while maintaining stability for users
 * Conduct competitive analysis of AI features in the market
-* Define acceptable accuracy thresholds and quality standards for AI outputs
+* Define acceptable accuracy thresholds and quality standards for AI outputs, establishing clear criteria for production readiness
 
 #### Executive Sponsor {.unnumbered}
 
 An Executive Sponsor champions AI transformation at the organizational level, securing resources, removing barriers, and ensuring AI initiatives align with strategic business objectives.
+
+Executive sponsors have become significantly more prominent compared to the classical ML era. GenAI projects typically have C-suite visibility from day one, meaning that managing expectations and communicating progress is now much more important and high-stakes. They need to balance extraordinary market pressure to adopt AI with legitimate concerns about risk, cost, and organizational readiness. 
 
 Primary Responsibilities:
 
 * Champion AI adoption and cultural transformation across the organization
 * Allocate budget for AI infrastructure, tools, and talent
 * Establish AI governance frameworks and ethical guidelines
-* Manage board and stakeholder communications about AI initiatives
-* Drive organizational change management for AI adoption
+* Manage board and stakeholder communications about AI initiatives, translating technical progress into business impact
+* Drive organizational change management for AI adoption, addressing both enthusiasm and resistance within the workforce
 * Set strategic direction for AI investment and risk tolerance
 * Ensure AI initiatives align with business strategy and compliance requirements 
 
 ### Emerging Specialized Roles
 
-While many organizations currently distribute these responsibilities among existing technical roles, leading companies are creating dedicated positions as AI systems become more complex and mission-critical.
+As AI solutions become more complex and mission critical, a number of specialized roles are beginning to appear (e.g. AI ethicist, prompt engineer, AI safety engineer). In many organizations today, however, these responsibilities remain distributed across existing teams (e.g. data, security, compliance) rather than being established as separate positions. Below is how these specializations are often handled in practice.
 
 #### AI Ethics Officer {.unnumbered}
 
@@ -121,92 +134,43 @@ An AI Ethics Officer is responsible for establishing and enforcing governance fr
 
 At present, these responsibilities are most often distributed across compliance officers (regulatory alignment), data governance teams (fairness and bias mitigation), and product or research leaders (responsible design and deployment). However, with the growing complexity of AI systems and the rise of formal regulations like the [EU AI Act](https://artificialintelligenceact.eu/the-act/), the need for a dedicated role is becoming increasingly clear. As a result, the AI Ethics Officer is emerging as a specialised function in larger organisations and regulated industries.
 
-Primary Responsibilities:
-
-* Develop and enforce responsible AI policies and frameworks
-* Conduct bias audits and fairness assessments of AI systems
-* Ensure compliance with AI regulations (EU AI Act, industry standards)
-* Lead AI governance committees and review boards
-* Manage stakeholder communications about AI ethics
-* Oversee data privacy and consent for AI systems
-* Document AI decision-making processes for accountability
-
-
 #### AI Safety Engineer {.unnumbered}
 
-An AI Safety Engineer acts as the security specialist for AI systems, implementing technical safeguards against adversarial attacks, harmful outputs, and system failures that traditional security approaches don't address. 
-
-In smaller organisations, these responsibilities are often distributed across AI engineers (who handle basic safety measures), security engineers (who manage traditional security concerns), or platform engineers (who oversee monitoring). However, the unique risks posed by AI, such as prompt injection, model manipulation, and hallucinations, are driving the need for specialised expertise. This trend is reinforced by the fact that leading AI labs like OpenAI, Anthropic, and DeepMind have dedicated AI safety teams, and both the [UK](https://www.gov.uk/government/publications/ai-safety-institute-overview/introducing-the-ai-safety-institute) and [US](https://www.nist.gov/caisi) governments established AI Safety Institutes to tackle these emerging challenges.
-
-Primary Responsibilities:
-
-* Implement guardrails against prompt injection and jailbreaking attempts
-* Build content filtering and moderation systems for AI outputs
-* Monitor for agent behavior drift and degradation in production
-* Develop testing frameworks for edge cases and failure modes
-* Create incident response procedures for AI failures
-* Implement audit trails for AI decision-making
-* Design fallback mechanisms and human-in-the-loop systems
-
+As organizations deploy AI in more sensitive and mission-critical contexts, safety concerns extend far beyond traditional cybersecurity. An AI Safety Engineer focuses on implementing safeguards against adversarial attacks, harmful outputs, and failure modes unique to AI systems. In practice, however, most companies do not employ this as a dedicated role. Instead, AI engineers are usually responsible for adding basic guardrails, security teams monitor risks like prompt injection and data leakage, and platform engineers watch for anomalies at the infrastructure level. Dedicated AI Safety Engineers are found primarily at AI research labs and large technology firms, where safety is central to product viability and public trust.
 
 #### LLMOps Engineer {.unnumbered}
 
-An LLMOps Engineer specializes in the operational complexities unique to large language models, including managing prompt versioning, token optimization, model routing and managing inference costs at scale. 
-
-While AI Engineers and Platform Engineers currently share these duties in most organizations, the complexity of managing multiple models, providers, and deployment patterns is driving specialization.
-
-Primary Responsibilities:
-
-* Manage prompt versioning and A/B testing systems
-* Optimize context windows and token usage across applications
-* Implement prompt caching and response caching strategies
-* Build routing systems for multi-model deployments
-* Monitor and optimize inference costs across different models
-* Create automated testing for prompt effectiveness
-* Manage model migrations and deprecations
+An LLMOps Engineer specializes in the operational complexities of large language models, including prompt versioning, token optimization, and multi-model routing. For most organizations today, these tasks are divided among AI engineers, who manage prompts and model selection, and platform engineers, who oversee infrastructure and monitoring. The role of LLMOps Engineer typically emerges in organizations with dozens of AI applications in production, where efficiency gains from specialization outweigh the overhead of another dedicated position.
 
 #### Prompt Engineer {.unnumbered}
 
-A Prompt Engineer translates business requirements into optimized instructions for AI models, systematically testing and refining prompts to improve accuracy while reducing costs. Today, these responsibilities are typically distributed among AI engineers (technical implementation), subject matter experts (domain knowledge), and product managers (use case definition). However, as organisations expand their use of generative AI, the complexity and scale of prompt design are driving the need for dedicated expertise. With prompt optimisation capable of delivering significant cost savings and the growing need for model-specific prompting techniques, specialised roles are becoming increasingly valuable.
+A Prompt Engineer translates business requirements into optimized instructions for AI models, systematically testing and refining prompts to improve accuracy while reducing costs. Today, these responsibilities are typically handled by AI Engineers who perform most prompt engineering, with input from SMEs for domain-specific language and Product Managers for user experience considerations. Dedicated prompt engineers are rare outside of AI-first companies.
 
-Primary Responsibilities:
+## Collaboration Patterns and Emerging Trends
 
-* Design and optimize prompt templates for specific business use cases
-* Create prompt libraries and maintain documentation
-* Conduct systematic testing of prompt variations
-* Train non-technical teams on effective AI tool usage
-* Develop prompt engineering guidelines and best practices
-* Implement few-shot learning examples and chain-of-thought prompting
-* Optimize prompts for different models and use cases
+Effective GenAI projects depend on strong cross-functional collaboration, with roles working together to align technical, operational, and business needs. Common collaboration patterns and trends are:
 
-## Key Role Interactions 
+#### Cross-functional teams {.unnumbered}
 
-Effective GenAI projects depend on strong cross-functional collaboration, with roles working together to align technical, operational, and business needs. Common collaboration patterns are:
+Agent implementation teams bring together AI Engineers, Data Engineers, and Platform Engineers in tight collaboration. Unlike traditional development where these roles might interact through tickets and handoffs, GenAI teams often work in the same physical or virtual space, making real-time decisions about architecture, cost trade-offs, and performance optimization. The complexity of RAG pipelines and agent behaviors requires constant coordination that can't be achieved through traditional organizational boundaries.
 
-#### Agent Implementation Team {.unnumbered}
+#### Continuous stakeholder engagement  {.unnumbered}
 
-**AI Engineer + Data Engineer + Platform Engineer**  
+Product development chains now operate in much tighter cycles. Where traditional development might have monthly stakeholder reviews, GenAI teams often demonstrate progress weekly or even daily. Product Managers, AI Engineers, and Software Engineers maintain constant communication channels, with many teams adopting "office hours" where stakeholders can see live demonstrations and provide immediate feedback.
 
-- Co-develop agentic GenAI solutions, including retrieval-augmented generation (RAG) pipelines and tool integrations  
-- Joint responsibility for solution scalability, reliability, and performance  
+#### Continous feedback loop  {.unnumbered}
 
-#### Product Development Chain  {.unnumbered}
+Unlike traditional software where user feedback might be collected through surveys or support tickets, GenAI systems enable continuous learning through every interaction. This has created new collaboration patterns where:
 
-**Product Manager + AI Engineer + Software Engineer**  
+* Data Engineers build real-time feedback pipelines
+* AI Engineers analyze interaction patterns to improve agents
+* SMEs review edge cases and failure modes
+* Product Managers adjust features based on immediate usage data
 
-- Translate business requirements into GenAI features step by step  
-- Ensure clear handoffs with defined success criteria  
+#### Governance as a core function  {.unnumbered}
 
-#### AI Governance Board  {.unnumbered}
-
-**AI Ethics Officer + AI Safety Engineer + Legal/Compliance**  
-
-- Review GenAI implementations for ethical and legal compliance  
-- Conduct risk assessments and define mitigation strategies  
+AI governance boards have evolved from quarterly review committees to active participants in the development process. The combination of AI Ethics Officers, AI Safety Engineers, and Legal/Compliance teams now provides continuous oversight rather than gate based reviews. 
 
 #### Cost Management Team  {.unnumbered}
 
-**Finance + Platform Engineer + AI Engineer**  
-
-- Monitor and optimize GenAI usage and infrastructure costs  
-- Track ROI and align budget with business priorities  
+As generative AI systems scale, costs can spiral quickly if left unchecked. A dedicated cost management team brings together finance, platform engineers, and AI engineers to keep usage and infrastructure spending under control. This group monitors resource consumption, tracks ROI, and ensures that budgets remain aligned with business priorities while still enabling innovation.

--- a/part3/roles-responsibilities.qmd
+++ b/part3/roles-responsibilities.qmd
@@ -36,7 +36,7 @@ Primary Responsibilities:
 * Create data pipelines that inject structured business data into AI prompts (customer records, product catalogs, transaction history)
 * Process unstructured documents for AI consumption
 * Handle multi-modal data preprocessing (images, audio, video) for specialized AI applications
-* Build and maintain vector databases for semantic search and RAG applications
+* Build and maintain vector databases for semantic search and document retrieval
 * Implement embedding pipelines using embedding models
 * Manage batch processing jobs for large-scale document embedding and updates
 * Prepare and version datasets for model fine-tuning when required

--- a/part3/roles-responsibilities.qmd
+++ b/part3/roles-responsibilities.qmd
@@ -86,7 +86,6 @@ Primary Responsibilities:
 * Define domain specific quality criteria and acceptance thresholds  
 * Bridge communication between technical teams and business stakeholders  
 * Ensure GenAI solutions comply with industry regulations and standards  
-* Create domain specific evaluation criteria for GenAI solution performance 
 
 ### Leadership and Strategy Roles
 

--- a/part3/roles-responsibilities.qmd
+++ b/part3/roles-responsibilities.qmd
@@ -38,7 +38,7 @@ Traditional data engineers are rapidly acquiring new skills in vector databases,
 
 Primary Responsibilities:
 
-* Design and maintain pipelines for structured data by delivering business data (e.g., customer records, product catalogs, transactions) into AI workflows by extracting from source systems, transforming into schemas, validating quality, and loading into feature stores or tables
+* Design and maintain structured data pipelines that connect business-level data (e.g., customer records, product catalogs, transactions) with AI workflows. These pipelines typically involve extracting data from source systems into schemas customized for a use case, validating data quality and sanitizing data to remove sensitive information
 * Build pipelines for unstructured documents such as PDFs, emails, and reports, using OCR and text extraction, metadata tagging, text cleaning, chunking large documents and conversion into structured formats (e.g. JSON).
 * Develop preprocessing workflows for multimodal data (images, audio, video), including resizing images, extracting features, transcribing audio, segmenting videos, generating metadata and storing the outputs.
 * Support retrieval and embedding systems by building and maintaining vector databases for semantic search, implementing embedding pipelines, and running batch jobs to embed and update large document collections.

--- a/part3/roles-responsibilities.qmd
+++ b/part3/roles-responsibilities.qmd
@@ -27,8 +27,7 @@ Primary Responsibilities:
 * Integrate and fine-tune existing LLMs with business logic and data sources, typically using APIs to pre-trained models
 * Develop tools that give AI agents access to APIs and proprietary and external data sources
 * Design and implement the agent behavior
-* Build evaluation and testing to ensure quality
-* Refine performance based on evaluation output and feedback
+* Build evaluation and testing suits to ensure quality
 * Optimize for cost and performance on the application logic level using prompt optimization, model selection, workflow design that minimizes API calls and response formatting that reduces token consumption.
 * Deploy AI agents into production with proper versioning and monitoring
 

--- a/references/references.bib
+++ b/references/references.bib
@@ -4,3 +4,29 @@
   journal={Journal of Agent Operations},
   year={2024}
 }
+
+@online{estrada2025mit,
+  title={MIT report: 95\% of generative AI pilots at companies are failing},
+  author={Estrada, Sheryl},
+  journal={Fortune},
+  year={2025},
+  month={August},
+  day={18},
+  url={https://fortune.com/2025/08/18/mit-report-95-percent-generative-ai-pilots-at-companies-failing-cfo/},
+  urldate={2025-01-03},
+  note={Based on MIT NANDA initiative report "The GenAI Divide: State of AI in Business 2025"}
+}
+
+@online{bick2024rapid,
+  title={The Rapid Adoption of Generative AI},
+  author={Bick, Alexander and Blandin, Adam and Deming, David},
+  journal={St. Louis Fed On the Economy},
+  institution={Federal Reserve Bank of St. Louis},
+  year={2024},
+  month={September},
+  day={23},
+  url={https://www.stlouisfed.org/on-the-economy/2024/sep/rapid-adoption-generative-ai},
+  urldate={2025-01-03},
+  note={Based on Real-Time Population Survey (RPS) data showing 40\% adoption rate in August 2024}
+}
+


### PR DESCRIPTION
- Add new AgentOps Project Pipeline guide (part1/agentops-project-pipeline.qmd)
  Goal is to show readers a prescriptive end-to-end example of an agent project with links to deep dives for each individual section to guide them through the full process. 

- Integrate evaluation content into continuous learning chapter with collaborative metric development and LLM-as-a-Judge calibration
  
- Update Quarto configuration to include new pipeline section
- Add academic references for MIT failure study and St. Louis Fed adoption data from project pipeline
- Minor addition to DevOps principles introduction